### PR TITLE
Favicon

### DIFF
--- a/contributors/contributor.html
+++ b/contributors/contributor.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-   <link rel="icon" href="Utils/20240921_154411.png">
+   <link rel="icon" href="./20240921_154411.png">
   <title>Tiffin Fusion</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">


### PR DESCRIPTION
Favicon Update for Contributors Page
The Contributors page now features a custom favicon to enhance the user experience and make the page visually distinct in the browser tab. This small, yet significant update ensures that the Contributors page is easily recognizable when users have multiple tabs open.

The favicon is a graphic icon that appears in the browser’s tab next to the page title, providing a more cohesive and professional look for the page. It improves branding by offering a quick visual representation of the page’s content, in this case, reflecting the theme or purpose of the Contributors section.
![Screenshot 2025-01-07 232240](https://github.com/user-attachments/assets/2bd99a8c-9c07-499f-ace1-cd78b0dc9efe)
