### PR TITLE
link broken issue solved

### DIFF
--- a/contributors/contributor.html
+++ b/contributors/contributor.html
@@ -62,7 +62,7 @@
 
         <!-- Contributors Link -->
         <li class="nav-item">
-          <a href="./contributors/contributor.html" class="nav-link mx-2">Contributors</a>
+          <a href="contributor.html" class="nav-link mx-2">Contributors</a>
         </li>
 
         <!-- Sign In Link -->


### PR DESCRIPTION
![link broken ](https://github.com/user-attachments/assets/6a213201-4b12-4b03-ae50-741a15a20fbe)
I have solved link broken issue that is when we click on contributors on contributors page navbar  the 404 error appears . . I solved this issue ...