### PR TITLE
Changed color to match UI in student plan page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Tiffin_Fusion",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/studentplan.css
+++ b/studentplan.css
@@ -72,7 +72,7 @@ body {
 }
 
 .card-front {
-    background: #fff;
+    background: #e03e00;
 }
 
 .card-image {
@@ -103,8 +103,8 @@ body {
 }
 
 .card-back {
-    background: #fff;
-    color: #333;
+    background: #e03e00 ;
+    color: #fff;
     transform: rotateY(180deg); /* Highlighted: Defined back face rotation */
     padding: 15px;
     box-sizing: border-box;

--- a/style.css
+++ b/style.css
@@ -1153,7 +1153,7 @@ html {
 }
 
 .read-more-button:hover {
-  background: #0056b3; /* Darker shade on hover */
+  background: #e03e00; /* Darker shade on hover */
 }
 
 


### PR DESCRIPTION
The original issue #103  was fixed by someone, So I made some improvement in student meal plan and blogs section on main page.

> On the blogs section on the main page, changed the "see more blog" button hover color from blue to orange to match with other buttons.

>On the student meal plan page, changed the flip card back background colour from white to orange in order to match with the color of flip card back on main page.

**Screenshots**
![Screenshot from 2025-01-10 15-47-50](https://github.com/user-attachments/assets/98f68091-29cb-4280-b352-3030a53a69f1)
![Screenshot from 2025-01-10 15-48-05](https://github.com/user-attachments/assets/c24ac028-c9cb-467d-8b1b-49a2c8fed725)
![Screenshot from 2025-01-10 15-50-35](https://github.com/user-attachments/assets/9d6daf96-c083-45c0-a7a3-8c09eeead161)
![Screenshot from 2025-01-10 15-54-53](https://github.com/user-attachments/assets/85757dd4-1255-4523-86db-078605c4dd2f)

This is a great project, and I would love to work more on it. [X](https://x.com/Rishabhdubeyy) can contact me on X for any frontend-related work.