### PR TITLE
Fixed menu toggler visibility issue #374 in dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="menu-toggle.css"
   <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
 </head>
 

--- a/menu-toggle.css
+++ b/menu-toggle.css
@@ -1,0 +1,4 @@
+.dark-mode .navbar-toggler-icon {
+    filter: invert(1); /* Makes the icon white */
+  }
+  


### PR DESCRIPTION
I have fixed the menu toggler visibility in dark mode . @saismrutiranjan18 
![image](https://github.com/user-attachments/assets/a6fbb5be-36fe-4f06-82ca-eb2d7678b30f)
![image](https://github.com/user-attachments/assets/1c00a434-ffc3-4050-9ec0-50de555b2167)
![image](https://github.com/user-attachments/assets/ef4a716f-218a-4dad-9000-609787a4290d)
